### PR TITLE
Add syntax highlighting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GG Flip
 
-Donald Knuth described in one of his TAOCP books that flipping the sign of a number is one of the hardest problems in Computer Science. But that was in the 60s. Thanks to years of research and after numerous publications, today have some interesting ways to do the same. Consider this: 
+Donald Knuth described in one of his TAOCP books that flipping the sign of a number is one of the hardest problems in Computer Science. But that was in the 60s. Thanks to years of research and after numerous publications, today have some interesting ways to do the same. Consider this:
 
-```
+```javascript
 x = 5
 // get -5
 x -= x*2;
@@ -23,7 +23,7 @@ go run main.go
 
 Above code generates highly readable file `lib.js`, which is:
 
-```
+```javascript
 function signFlip(num) {
     switch (num) {
         case 0:


### PR DESCRIPTION
Can't advertise high-performance sign flipping if reading your README is low-performance!

Before: ![before SS](https://user-images.githubusercontent.com/6709544/35183134-39dc62f0-fde1-11e7-857e-e7a5f36c6ab4.png)

After: ![after SS](https://user-images.githubusercontent.com/6709544/35183133-39b82ce6-fde1-11e7-9469-374dec4d2bff.png)